### PR TITLE
Update package.json

### DIFF
--- a/ports/awsiot/example/package.json
+++ b/ports/awsiot/example/package.json
@@ -6,6 +6,6 @@
     "start": "AWSIOT_CONFIG_FILE=./config.json NODE_RED_DIR=../../../node-red enebular-awsiot-agent"
   },
   "dependencies": {
-    "enebular-awsiot-agent": "file:.."
+    "enebular-awsiot-agent": "enebular/enebular-awsiot-agent"
   }
 }


### PR DESCRIPTION
この package.json をそのまま npm install しても、enebular aws iot agent  の参照先がないため、enebular aws iot agent がインストールできなず、enebular runtime agent を起動できない。

起動のコマンドは下記。
[ここ](http://docs.enebular.com/ja/Deploy/DeployFlow/AWSIoT/)に記載してあるものと同じ。
```
cd example
npm install
DEBUG=info npm run start
```